### PR TITLE
Require NativeModules via React Native package

### DIFF
--- a/RNClipboard.js
+++ b/RNClipboard.js
@@ -1,6 +1,6 @@
 'use strict';
 
-var RNClipboard = require('NativeModules').RNClipboard;
+var RNClipboard = require('react-native').NativeModules.RNClipboard;
 
 var Clipboard = {
     get(callback) {


### PR DESCRIPTION
As of RN v0.7.0 all require statements for React Native modules should
go through the public interface. This patch suppresses the warning when
building the package and ensures the library won’t break in the future.
