### PR TITLE
Remove application definition from AndroidManifest.xml

### DIFF
--- a/RNClipboardAndroid/app/src/main/AndroidManifest.xml
+++ b/RNClipboardAndroid/app/src/main/AndroidManifest.xml
@@ -1,10 +1,3 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     package="com.davidsandor.rnclipboardandroid">
-
-    <application android:allowBackup="true" android:label="@string/app_name"
-        android:icon="@mipmap/ic_launcher" android:supportsRtl="true"
-        android:theme="@style/AppTheme">
-
-    </application>
-
 </manifest>


### PR DESCRIPTION
Is this necessary?

I had to remove before adding this to my react-native project, because I'm setting the application name a bit differently so the compiler errors out:

```
app/src/main/AndroidManifest.xml:10:7-39 Error:
    Attribute application@label from AndroidManifest.xml:10:7-39
    is also present at [Lugg:react-native-clipboard:unspecified] AndroidManifest.xml:14:9-41 value=(@string/app_name)
```

Seems to work fine without it.
